### PR TITLE
Combobox: Add subheading autocomplete pattern

### DIFF
--- a/components/combobox/__examples__/base-menu-subheader.jsx
+++ b/components/combobox/__examples__/base-menu-subheader.jsx
@@ -2,15 +2,24 @@
 import React from 'react';
 import Combobox from '~/components/combobox';
 import Icon from '~/components/icon';
+import comboboxAddSubheadings from '~/components/combobox/add-subheadings';
 import comboboxFilterAndLimit from '~/components/combobox/filter';
 import IconSettings from '~/components/icon-settings';
 
-const accounts = [
+const subheadings = [
 	{
-		id: '0',
+		id: 'account',
 		label: 'Accounts',
 		type: 'separator',
 	},
+	{
+		id: 'opportunity',
+		label: 'Opportunities',
+		type: 'separator',
+	},
+];
+
+const accounts = [
 	{
 		id: '1',
 		label: 'Acme',
@@ -31,14 +40,9 @@ const accounts = [
 	},
 	{
 		id: '4',
-		label: 'Opportunities',
-		subTitle: 'Opportunity • San Francisco, CA',
+		label: 'Vandelay Industries',
+		subTitle: 'Account • San Francisco, CA',
 		type: 'account',
-	},
-	{
-		id: '5',
-		label: 'Opportunities',
-		type: 'separator',
 	},
 	{
 		id: '6',
@@ -135,11 +139,14 @@ class Example extends React.Component {
 						placeholder: 'Search Salesforce',
 					}}
 					multiple
-					options={comboboxFilterAndLimit({
-						inputValue: this.state.inputValue,
-						limit: 10,
-						options: accountsWithIcon,
-						selection: this.state.selection,
+					options={comboboxAddSubheadings({
+						subheadings,
+						filteredOptions: comboboxFilterAndLimit({
+							inputValue: this.state.inputValue,
+							limit: 10,
+							options: accountsWithIcon,
+							selection: this.state.selection,
+						}),
 					})}
 					selection={this.state.selection}
 					value={this.state.inputValue}

--- a/components/combobox/add-subheadings.js
+++ b/components/combobox/add-subheadings.js
@@ -1,0 +1,46 @@
+/* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
+/* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
+
+/**
+ * This is a UX pattern recommendation for auto-complete search results that can contain multiple subheadings within the results. It inserts a subheading object based on `option.type === subheading.id` directly before a found option object and only inserts the subheading at the first occurence of that type of option.
+ */
+
+const filterWithSubheadings = ({ subheadings, filteredOptions }) => {
+	// Let's not mutate things we don't own.
+	let subheadingsNotPresent = [...subheadings];
+
+	const filteredOptionsWithSubheadings = filteredOptions.map((option) => {
+		let subheadingRelatedToFilteredOption;
+
+		// Remove subheadings that have been found from
+		// `subheadingsNotPresent` and flag if they are
+		// found.
+		subheadingsNotPresent = subheadingsNotPresent.filter((subheading) => {
+			let subheadingNotPresentInFilteredOptions = true;
+			if (option.type === subheading.id) {
+				subheadingRelatedToFilteredOption = subheading;
+				subheadingNotPresentInFilteredOptions = false;
+			}
+			return subheadingNotPresentInFilteredOptions;
+		});
+
+		// So that they can be inserted into the current filtered
+		// options in a child array with the first related option
+		// OUTPUT
+		// Array [
+		//   0: Array [
+		//     0: {id: "account", label: "Accounts", type: "separator"}
+		//     1: {id: "1", label: "Acme", type: "account"}
+		//   ]
+		// ]
+		return subheadingRelatedToFilteredOption
+			? [subheadingRelatedToFilteredOption, option]
+			: [option];
+	});
+
+	// flatten and remove child arrays, so that we have one array
+	// `...`` operates on each array item, not the array
+	return [].concat(...filteredOptionsWithSubheadings);
+};
+
+export default filterWithSubheadings;

--- a/components/combobox/filter.js
+++ b/components/combobox/filter.js
@@ -11,11 +11,11 @@ const filter = ({ inputValue, limit = 10, options, selection }) =>
 			const searchTermFound = option.label
 				? option.label.match(new RegExp(escapeRegExp(inputValue), 'ig'))
 				: false;
-			const isSection = option.data && option.data.type === 'section';
+			const isSeparator = option.type === 'separator';
 			const notAlreadySelected = !selection.includes(option);
 
 			return (
-				(!inputValue || isSection || searchTermFound) && notAlreadySelected
+				(!inputValue || isSeparator || searchTermFound) && notAlreadySelected
 			);
 		})
 		.splice(0, limit);


### PR DESCRIPTION
Please look over this before merging in. This was somewhat thrown together and probably isn't very performant, but does show the UX patterns of hiding subheaders that do not have items under them. You probably have a better idea on how to manipulate the data.

It inserts a subheading based on `option.type === subheading.id` directly before a found item and only do it once.